### PR TITLE
Feat/ssml

### DIFF
--- a/events/cancel.json
+++ b/events/cancel.json
@@ -1,0 +1,8 @@
+{
+  "request": {
+    "type": "IntentRequest",
+    "intent": {
+      "name": "AMAZON.CancelIntent"
+    }
+  }
+}

--- a/handler.ts
+++ b/handler.ts
@@ -2,6 +2,7 @@ import "source-map-support/register";
 import Alexa = require("ask-sdk-core");
 import { RequestEnvelope } from "ask-sdk-model";
 import { Callback, Context, Handler } from "aws-lambda";
+import Speech = require("ssml-builder");
 
 const skillName = "Thermometer";
 
@@ -69,9 +70,14 @@ const CancelAndStopIntentHandler = {
   },
   handle(handlerInput) {
     const speechText = "さようなら";
+    const speech = new Speech();
+    speech.sayAs({
+      word: speechText,
+      interpret: "interjection"
+    });
 
     return handlerInput.responseBuilder
-      .speak(speechText)
+      .speak(speech.ssml(true))
       .withSimpleCard(skillName, speechText)
       .getResponse();
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "ask-sdk-core": "^2.0.7",
-    "ask-sdk-model": "^1.4.1"
+    "ask-sdk-model": "^1.4.1",
+    "ssml-builder": "^0.4.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,6 +2032,10 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+ssml-builder@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/ssml-builder/-/ssml-builder-0.4.3.tgz#40c5f71a541588ecdc1ae9987c48eb12122cc63d"
+
 ssri@^5.2.4:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"


### PR DESCRIPTION
Use SSML builder

memo

SSML builder 自体は Alexa SDK V2 に対応してないが、
SDK がデフォルトで `<speak>` タグで囲む仕様は変わってないので、
使い方はそのままで良い